### PR TITLE
Add script to strip markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _build
 dist
 vuepress/dist
 .netlify
+stripped-docs
 
 yarn.lock
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "serve": "vuepress dev --no-cache",
-    "build": "vuepress build --no-cache"
+    "build": "vuepress build --no-cache",
+    "strip-markdown": "rm -rf stripped-docs/* && node scripts/strip-markdown"
   },
   "repository": {
     "type": "git",
@@ -19,5 +20,9 @@
   "homepage": "https://github.com/CosmWasm/docs",
   "dependencies": {
     "vuepress-theme-cosmos": "^1.0.167"
+  },
+  "devDependencies": {
+    "filehound": "^1.17.4",
+    "remove-markdown": "^0.3.0"
   }
 }

--- a/scripts/strip-markdown.js
+++ b/scripts/strip-markdown.js
@@ -1,0 +1,21 @@
+const Filehound = require('filehound')
+const removeMd = require('remove-markdown')
+const fs = require('fs-extra')
+
+const files = Filehound.create()
+  .ext('md')
+  .paths('../docs2')
+  .discard('.node_modules')
+  .find((err, mdFiles) => {
+    if (err) return console.error('handle err', err)
+  })
+
+files.then(files => {
+  files.map(file => {
+    console.log(file)
+    const content = fs.readFileSync(file, 'utf8')
+    const plaintext = removeMd(content)
+    const filename = file.replace('../docs2', './stripped-docs')
+    fs.outputFileSync(filename, plaintext)
+  })
+})


### PR DESCRIPTION
It's convenient to run your code through a grammar checker. Grammar correctors do not work correctly when markdown syntax is there. This simple script I wrote some months ago is pretty useful for this reason. It creates the folder `stripped-docs` that contains markdown syntax free docs as a result. 