### PR TITLE
Docs fix

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -13,6 +13,9 @@ module.exports = {
     logo: {
       src: "/logo/SVG/CosmWasm Logo.svg",
     },
+    topbar: {
+      banner: false
+    },
     sidebar: {
       auto: false,
       nav: [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/CosmWasm/docs",
   "dependencies": {
-    "vuepress-theme-cosmos": "1.0.167"
+    "vuepress-theme-cosmos": "^1.0.169"
   },
   "devDependencies": {
     "filehound": "^1.17.4",


### PR DESCRIPTION
closes https://github.com/cosmos/vuepress-theme-cosmos/issues/86

- bump docs theme to the latest
- disabled topbar banner in config.js