### PR TITLE
getting-started: swap wasm exec to coral exec

### DIFF
--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -59,14 +59,43 @@ make install
 wasmcli version
 ```
 
+::: tip
 If you have any problems here, check your `PATH`. `make install` will copy `wasmcli` to
 `$HOME/go/bin` by default, please make sure that is set up in your `PATH` as well, which should be
 the case in general for building Go code from source.
+:::
+
+## Using Testnets
+
+Long term testing network [Coralnet](https://github.com/CosmWasm/testnets/tree/master/coralnet) is launched to
+save you of the hassle of running a local network and speed up your developments. To use __coralnet__, you need to use
+`coral/corald` executables instead `wasmcli/wasmd` which are basically same executables just some extra configurations during
+compile time such as `Bech32` prefix.
+
+```sh
+# clone wasmd repo
+git clone https://github.com/CosmWasm/wasmd.git && cd wasmd
+# check out to coral compatibile version
+git checkout v0.10.0
+
+# build coral executables
+make build-coral
+
+# executables are in `./build`, export to path them or move them to go bin
+export PATH="${PATH}:$(pwd)/build"
+
+# move to bin
+mv ./build/coral* $GOBIN
+```
 
 ## Further Information on the Cosmos SDK
 
-`wasmcli` and `wasmd` are forks of `gaiacli` and `gaiad`, which are the binaries that run the Cosmos
-Hub ([source](https://github.com/cosmos/gaia)). These represent an instance of a blockchain that
+::: tip
+`wasmcli` and `wasmd` (including `corald/gaiaflex`) are forks of `gaiacli` and `gaiad`, which are the binaries that run the Cosmos
+Hub ([source](https://github.com/cosmos/gaia)).
+:::
+
+These represent an instance of a blockchain that
 utilizes all of the stable features of the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk). As
 such, `wasmcli` and `wasmd` have all the same features (plus WASM smart contracts obviously). If
 you'd like to learn more about accessing those features take a look at the [Gaia

--- a/getting-started/interact-with-contract.md
+++ b/getting-started/interact-with-contract.md
@@ -14,18 +14,20 @@ upload the code to the blockchain. Afterwards, you can download the bytecode to 
 
 ```bash
 # see how many codes we have now
-wasmcli query wasm list-code
+coral query wasm list-code
 
 # gas is huge due to wasm size... but auto-zipping reduced this from 1.8M to around 600k
 # you can see the code in the result
-RES=$(wasmcli tx wasm store contract.wasm --from fred --gas 900000 -y)
+RES=$(coral tx wasm store contract.wasm --from fred --gas 900000 -y)
+
 # you can also get the code this way
 CODE_ID=$(echo $RES | jq -r '.logs[0].events[0].attributes[-1].value')
+
 # no contracts yet, this should return `null`
-wasmcli query wasm list-contract-by-code $CODE_ID
+coral query wasm list-contract-by-code $CODE_ID
 
 # you can also download the wasm from the chain and check that the diff between them is empty
-wasmcli query wasm code $CODE_ID download.wasm
+coral query wasm code $CODE_ID download.wasm
 diff contract.wasm download.wasm
 ```
 
@@ -36,19 +38,22 @@ will allow fred to control payout and upon release, the funds go to bob.
 
 ```bash
 # instantiate contract and verify
-INIT=$(jq -n --arg fred $(wasmcli keys show -a fred) --arg bob $(wasmcli keys show -a bob) '{"arbiter":$fred,"recipient":$bob}')
-wasmcli tx wasm instantiate $CODE_ID "$INIT" --from fred --amount=50000ucosm  --label "escrow 1" -y
+INIT=$(jq -n --arg fred $(coral keys show -a fred) --arg bob $(coral keys show -a bob) '{"arbiter":$fred,"recipient":$bob}')
+coral tx wasm instantiate $CODE_ID "$INIT" \
+    --from fred --amount=50000ucosm  --label "escrow 1" \
+    --gas-prices="0.025ushell" --gas="auto" --gas-adjustment="1.2" -y
 
 # check the contract state (and account balance)
-wasmcli query wasm list-contract-by-code $CODE_ID
-CONTRACT=$(wasmcli query wasm list-contract-by-code $CODE_ID | jq -r '.[0].address')
+coral query wasm list-contract-by-code $CODE_ID
+CONTRACT=$(coral query wasm list-contract-by-code $CODE_ID | jq -r '.[0].address')
 echo $CONTRACT
+
 # we should see this contract with 50000ucosm
-wasmcli query wasm contract $CONTRACT
-wasmcli query account $CONTRACT
+coral query wasm contract $CONTRACT
+coral query account $CONTRACT
 
 # you can dump entire contract state
-wasmcli query wasm contract-state all $CONTRACT
+coral query wasm contract-state all $CONTRACT
 
 # note that we prefix the key "config" with two bytes indicating it's length
 # echo -n config | xxd -ps
@@ -56,16 +61,16 @@ wasmcli query wasm contract-state all $CONTRACT
 # thus we have a key 0006636f6e666967
 
 # you can also query one key directly
-wasmcli query wasm contract-state raw $CONTRACT 0006636f6e666967 --hex
+coral query wasm contract-state raw $CONTRACT 0006636f6e666967 --hex
 
 # Note that keys are hex encoded, and val is base64 encoded.
 # To view the returned data (assuming it is ascii), try something like:
 # (Note that in many cases the binary data returned is non in ascii format, thus the encoding)
-wasmcli query wasm contract-state all $CONTRACT | jq -r '.[0].key' | xxd -r -ps
-wasmcli query wasm contract-state all $CONTRACT | jq -r '.[0].val' | base64 -d
+coral query wasm contract-state all $CONTRACT | jq -r '.[0].key' | xxd -r -ps
+coral query wasm contract-state all $CONTRACT | jq -r '.[0].val' | base64 -d
 
 # or try a "smart query", executing against the contract
-wasmcli query wasm contract-state smart $CONTRACT '{}'
+coral query wasm contract-state smart $CONTRACT '{}'
 # (since we didn't implement any valid QueryMsg, we just get a parse error back)
 ```
 
@@ -74,17 +79,24 @@ that is not the verifier, then using the proper key to release.
 
 ```bash
 # execute fails if wrong person
-APPROVE='{"approve":{"quantity":[{"amount":"50000","denom":"ucosm"}]}}'
-wasmcli tx wasm execute $CONTRACT "$APPROVE" --from thief -y
+APPROVE='{"approve":{"quantity":[{"amount":"50000","denom":"ushell"}]}}'
+coral tx wasm execute $CONTRACT "$APPROVE" \
+    --from thief \
+    -gas-prices="0.025ushell" --gas="auto" --gas-adjustment="1.2" -y
+
 # looking at the logs should show: "execute wasm contract failed: Unauthorized"
 # and bob should still be broke (and broken showing the account does not exist Error)
-wasmcli query account $(wasmcli keys show bob -a)
+coral query account $(coral keys show bob -a)
 
 # but succeeds when fred tries
-wasmcli tx wasm execute $CONTRACT "$APPROVE" --from fred -y
-wasmcli query account $(wasmcli keys show bob -a)
+coral tx wasm execute $CONTRACT "$APPROVE" \
+    --from fred \
+    -gas-prices="0.025ushell" --gas="auto" --gas-adjustment="1.2" -y
+
+coral query account $(coral keys show bob -a)
+
 # contract coins must be empty
-wasmcli query account $CONTRACT
+coral query account $CONTRACT
 ```
 
 ## Node Console
@@ -96,7 +108,7 @@ is a bit nicer in JavaScript than in Shell Script.
 First, go to the cli directory and start up your console:
 
 ```sh
-npx @cosmjs/cli --init https://raw.githubusercontent.com/CosmWasm/testnets/master/demo-10/cli_helper.ts
+npx @cosmjs/cli --init https://raw.githubusercontent.com/CosmWasm/testnets/master/coralnet/cli_helper.ts
 ```
 
 Now, we make all the keys and initialize clients:
@@ -108,7 +120,7 @@ const {address: fredAddr, client: fredClient} = await connect(fredSeed, {});
 // bob doesn't have a client here as we will not
 // submit any tx with this account, just query balance
 const bobSeed = loadOrCreateMnemonic("bob.key");
-const bobAddr = await mnemonicToAddress("cosmos", bobSeed);
+const bobAddr = await mnemonicToAddress("coral", bobSeed);
 
 const thiefSeed = loadOrCreateMnemonic("thief.key");
 
@@ -122,12 +134,12 @@ Hit the faucet it needed for fred , so he has tokens to submit transactions:
 ```js
 fredClient.getAccount();
 // if "undefined", do the following
-hitFaucet(defaultFaucetUrl, fredAddr, "COSM")
+hitFaucet(defaultFaucetUrl, fredAddr, "SHELL")
 fredClient.getAccount();
 
 thiefClient.getAccount();
 // if "undefined", do the following
-hitFaucet(defaultFaucetUrl, thiefAddr, "COSM")
+hitFaucet(defaultFaucetUrl, thiefAddr, "SHELL")
 thiefClient.getAccount();
 
 // check bobAddr has no funds
@@ -150,7 +162,7 @@ console.log(up);
 const { codeId } = up;
 
 const initMsg = {arbiter: fredAddr, recipient: bobAddr};
-const { contractAddress } = await fredClient.instantiate(codeId, initMsg, "Escrow 1", { memo: "memo", transferAmount: [{denom: "ucosm", amount: "50000"}]});
+const { contractAddress } = await fredClient.instantiate(codeId, initMsg, "Escrow 1", { memo: "memo", transferAmount: [{denom: "ushell", amount: "50000"}]});
 
 // check the contract is set up properly
 console.log(contractAddress);
@@ -170,7 +182,7 @@ Once we have properly configured the contract, let's show how to use it, both th
 command:
 
 ```js
-const approve = {approve: {quantity: [{amount: "50000", denom: "ucosm"}]}};
+const approve = {approve: {quantity: [{amount: "50000", denom: "ushell"}]}};
 
 // thief cannot approve
 thiefClient.execute(contractAddress, approve)

--- a/getting-started/intro.md
+++ b/getting-started/intro.md
@@ -14,7 +14,7 @@ We will not dive into smart contract development in this section to provide an e
 introduction. Also, you can follow the steps here to test out smart contracts live on a testnet
 without drowning in smart contract development details. We will demonstrate setting up environment,
 compiling, deploying, and interacting. Then to make things a bit more interesting, we will
-demonstrate modifying the example escrow contract by adding a backdoor to it in the [Hijack Escrow
+show modifying the example escrow contract by adding a backdoor to it in the [Hijack Escrow
 tutorial](../learn/hijack-escrow/intro.md). It exposes an identical API to the original one, but has
 one hidden command added. This also shows the importance of verifying the source code behind any
 contract you run.

--- a/getting-started/setting-env.md
+++ b/getting-started/setting-env.md
@@ -5,67 +5,84 @@ order: 3
 # Setting Up Environment
 
 You need an environment to run contracts. You can either run your node locally or connect to an
-existing network. For easy testing, we have a demo net online you can use to deploy and run your
+existing network. For easy testing, long living coral network is online, you can use it to deploy and run your
 contracts. If you want to setup and run against a local blockchain, [click
 here](#run-local-node-optional)
 
 To verify testnet is currently running, make sure the following URLs are all working for you:
 
-- https://rpc.demo-10.cosmwasm.com/status
-- https://faucet.demo-10.cosmwasm.com/status
-- https://lcd.demo-10.cosmwasm.com/node_info
+- [https://rpc.coralnet.cosmwasm.com/status](https://rpc.coralnet.cosmwasm.com/status)
+- [https://faucet.coralnet.cosmwasm.com/status](https://faucet.coralnet.cosmwasm.com/status)
+- [https://lcd.coralnet.cosmwasm.com/node_info](https://lcd.coralnet.cosmwasm.com/node_info)
 
-We have set up two native tokens - `STAKE` (`ustake`) for being a validator and `COSM` (`ucosm`) for
-paying fees. We currently don't have any frontends (lunie, hubble, cosmostation, etc) that work with
-the demo net, but feel free to deploy one pointing to our rpc/lcd servers and we will list it.
+We have set up two native tokens - `REEF` (`ureef`) for being a validator and `SHELL` (`ushell`) for
+paying fees.
+Available frontends:
+
+- [Big-dipper block explorer](https://bigdipper.coralnet.cosmwasm.com/)
+- [wasm.glass contract explorer](https://coralnet.wasm.glass/#)
+
+You can use these to explore txs, addresses, validators and contracts
+feel free to deploy one pointing to our rpc/lcd servers and we will list it.
 
 You can find more information about other testnets:
 [CosmWasm/testnets](https://github.com/CosmWasm/testnets) and [Testnet
 section](./../testnets/testnets.md).
 
-When interacting with network, you can either use `wasmcli` which is a GO client or Node REPL.
-Depends solely on your preference.
+When interacting with network, you can either use `coral` which is a GO client or Node REPL. Altough Node REPL is
+recommended for contract operations, since JSON manipulation is not intuitive with bash/go client.
 
 ## Setup GO CLI
 
-Let's configure `wasmcli`, point it to testnets, create wallet and ask tokens from faucet:
+Let's configure `coral` exec, point it to testnets, create wallet and ask tokens from faucet:
+
+First source the coral network configurations to the shell:
 
 ```sh
-wasmcli config chain-id testing
-wasmcli config trust-node true
-# if connecting to local node, wasmcli config node http://localhost:26657
-wasmcli config node https://rpc.demo-10.cosmwasm.com:443
-wasmcli config output json
-wasmcli config indent true
+source <(curl -sSL https://raw.githubusercontent.com/CosmWasm/testnets/master/coralnet/defaults.env)
+```
+
+Setup the client:
+
+```sh
+coral config chain-id $CHAIN_ID
+coral config trust-node true
+
+# if connecting to local node: coral config node http://localhost:26657
+coral config node $RPC
+coral config output json
+coral config indent true
+
 # this is important, so the cli returns after the tx is in a block,
 # and subsequent queries return the proper results
-wasmcli config broadcast-mode block
+coral config broadcast-mode block
 
 # check you can connect
-wasmcli query supply total
-wasmcli query staking validators
-wasmcli query wasm list-code
+coral query supply total
+coral query staking validators
+coral query wasm list-code
 
 # add more wallets for testing
-wasmcli keys add fred
+coral keys add fred
 >
 {
   "name": "fred",
   "type": "local",
-  "address": "cosmos1avdvl5aje3zt0uay40uj6l9xtqtlqhduu84nql",
-  "pubkey": "cosmospub1addwnpepqvcjveqepq34x59fnmygdy58ag7zwu8gefgsprq9th38nxzptpgszc3rkve",
+  "address": "coral1avdvl5aje3zt0uay40uj6l9xtqtlqhduu84nql",
+  "pubkey": "coralpub1addwnpepqvcjveqepq34x59fnmygdy58ag7zwu8gefgsprq9th38nxzptpgszc3rkve",
   "mnemonic": "hobby bunker rotate piano satoshi planet network verify else market spring toward pledge turkey tip slim word jaguar congress thumb flag project chalk inspire"
 }
-wasmcli keys add bob
-wasmcli keys add thief
+
+coral keys add bob
+coral keys add thief
 ```
 
 You need some tokens in your address to interact. If you are using local node you can skip this
 step. Requesting tokens from faucet:
 
 ```sh
-JSON=$(jq -n --arg addr $(wasmcli keys show -a fred) '{"ticker":"COSM","address":$addr}') && curl -X POST --header "Content-Type: application/json" --data "$JSON" https://faucet.demo-10.cosmwasm.com/credit
-JSON=$(jq -n --arg addr $(wasmcli keys show -a thief) '{"ticker":"COSM","address":$addr}') && curl -X POST --header "Content-Type: application/json" --data "$JSON" https://faucet.demo-10.cosmwasm.com/credit
+JSON=$(jq -n --arg addr $(coral keys show -a fred) '{"ticker":"COSM","address":$addr}') && curl -X POST --header "Content-Type: application/json" --data "$JSON" https://faucet.coralnet.cosmwasm.com/credit
+JSON=$(jq -n --arg addr $(coral keys show -a thief) '{"ticker":"COSM","address":$addr}') && curl -X POST --header "Content-Type: application/json" --data "$JSON" https://faucet.coralnet.cosmwasm.com/credit
 ```
 
 ## Setup Node REPL
@@ -85,8 +102,6 @@ network configurations you can use on-the-fly:
 ```sh
 ## CORALNET
 npx @cosmjs/cli --init https://raw.githubusercontent.com/CosmWasm/testnets/master/coralnet/cli_helper.ts
-## DEMONET
-npx @cosmjs/cli --init https://raw.githubusercontent.com/CosmWasm/testnets/master/demo-10/cli_helper.ts
 ```
 
 Using the REPL:
@@ -94,14 +109,14 @@ Using the REPL:
 ```js
 // Create or load account
 const mnemonic = loadOrCreateMnemonic('fred.key')
-mnemonicToAddress('cosmos', mnemonic)
+mnemonicToAddress('coral', mnemonic)
 
 const { address, client } = await connect(mnemonic, {})
 address
 
 client.getAccount()
 // if empty - this only works with CosmWasm
-hitFaucet(defaultFaucetUrl, address, 'COSM')
+hitFaucet(defaultFaucetUrl, address, 'SHELL')
 client.getAccount()
 ```
 
@@ -112,7 +127,8 @@ If you are interested in running your local network you can use the script below
 ```sh
 # initialize wasmd configuration files
 wasmd init localnet
-# setup wasmcli
+
+# setup local node
 wasmcli config chain-id localnet
 wasmcli config trust-node true
 wasmcli config node http://localhost:26657
@@ -121,12 +137,16 @@ wasmcli config output json
 # add your wallet addresses to genesis
 wasmd add-genesis-account $(wasmcli keys show -a fred) 10000000000ucosm,10000000000stake
 wasmd add-genesis-account $(wasmcli keys show -a thief) 10000000000ucosm,10000000000stake
+
 # add fred's address as validator's address
 wasmd gentx --name fred
+
 # collect gentxs to genesis
 wasmd collect-gentxs
+
 # validate the genesis file
 wasmd validate-genesis
+
 # run the node
 wasmd start
 ```

--- a/testnets/testnets.md
+++ b/testnets/testnets.md
@@ -142,9 +142,11 @@ coral rest-server --node tcp://<host>:<port>
 
 ## Joining To Be Launched Testnets
 
+::: tip
 You need to have your address and informations defined in networks genesis file to join not yet launched testnets.
 Here is the script you can run to take care of it automatically. It uses `coral` [network specific executables](https://github.com/CosmWasm/testnets/tree/master/coralnet):
-
+:::
+  
 ```sh
 cd $CW_DIR
 ## Fork github.com:CosmWasm/testnets to your account and clone.


### PR DESCRIPTION
People that started to use CW(CosmWasmers? 🤣 ) are getting confused by the difference of `wasmcli/coral` in getting started section. I renamed `wasmcli` to `coral` and did some small changes to docs(add block-explorer, improve gas in commands, etc).