### PR TITLE
Fix incorrect steps in the documentation

### DIFF
--- a/getting-started/compile-contract.md
+++ b/getting-started/compile-contract.md
@@ -19,8 +19,8 @@ to a pre-defined beneficiary. First, clone the repo and try to build the wasm bu
 ```shell
 # get the code
 git clone https://github.com/CosmWasm/cosmwasm-examples
-cd cosmwasm-examples/escrow
 git checkout escrow-0.7.0
+cd cosmwasm-examples/escrow
 
 # compile the wasm contract with stable toolchain
 rustup default stable

--- a/getting-started/interact-with-contract.md
+++ b/getting-started/interact-with-contract.md
@@ -43,8 +43,8 @@ wasmd tx wasm instantiate $CODE_ID "$INIT" \
     --from fred --amount=50000umayo  --label "escrow 1" $TXFLAG -y
 
 # check the contract state (and account balance)
-wasmd query wasm list-contract-by-code $CODE_ID $NODE
-CONTRACT=$(wasmd query wasm list-contract-by-code $CODE_ID $NODE | jq -r '.[0].address')
+wasmd query wasm list-contract-by-code $CODE_ID $NODE --output=json
+CONTRACT=$(wasmd query wasm list-contract-by-code $CODE_ID $NODE --output=json | jq -r '.[0].address')
 echo $CONTRACT
 
 # we should see this contract with 50000umayo


### PR DESCRIPTION
- Fix the git clone command as `CosmWasm/cosmwasm-examples` has updated its `master` branch directory structure
- Force `cosmwasm` to output as JSON in one of the commands for extracting information