### PR TITLE
cw20: fix link in staking spec

### DIFF
--- a/cw-plus/cw20/06-cw20-staking-spec.md
+++ b/cw-plus/cw20/06-cw20-staking-spec.md
@@ -5,7 +5,7 @@ order: 6
 
 # CW20 Staking Derivates
 
-cw20-staking source code: [https://github.com/CosmWasm/cosmwasm-plus/tree/master/contracts/cw20-escrow](https://github.com/CosmWasm/cosmwasm-plus/tree/master/contracts/cw20-escrow)
+cw20-staking source code: [https://github.com/CosmWasm/cosmwasm-plus/tree/master/contracts/cw20-staking](https://github.com/CosmWasm/cosmwasm-plus/tree/master/contracts/cw20-staking)
 This is a sample contract that releases a minimal form of staking derivatives.
 This is to be used for integration tests and as a foundation for other to build
 more complex logic upon.


### PR DESCRIPTION
## Description

Link led to escrow contract from the staking spec