### PR TITLE
Update compile-contract.md

### DIFF
--- a/getting-started/compile-contract.md
+++ b/getting-started/compile-contract.md
@@ -22,7 +22,7 @@ git clone https://github.com/CosmWasm/cosmwasm-examples
 cd cosmwasm-examples
 git fetch --tags
 git checkout escrow-0.10.0
-cd escrow
+cd contracts/escrow
 
 # compile the wasm contract with stable toolchain
 rustup default stable


### PR DESCRIPTION
the tagged version has no escrow folder directly, its placed under contracts directory

https://github.com/CosmWasm/cosmwasm-examples/tree/escrow-0.10.0/contracts/escrow