### PR TITLE
doc: fix wallet name issue in execute command

### DIFF
--- a/docs_versioned_docs/version-0.16/02-getting-started/05-interact-with-contract.md
+++ b/docs_versioned_docs/version-0.16/02-getting-started/05-interact-with-contract.md
@@ -81,7 +81,7 @@ wasmd query wasm contract-state smart $CONTRACT "$NAME_QUERY" $NODE --output jso
 TRANSFER='{"transfer":{"name":"fred","to":"wasm1um2e88neq8sxzuuem5ztt9d0em033rpr5ps9tv"}}'
 wasmd tx wasm execute $CONTRACT "$TRANSFER" \
     --amount 999upebble \
-    --from wallet2 $TXFLAG -y
+    --from wallet $TXFLAG -y
 ```
 
 Query record to see the new owner address:


### PR DESCRIPTION
The transfer execute transaction should use `wallet` rather than `wallet2` to perform the call since the owner is the account associated to `wallet` key.
With the current sample command the execution gives an error:
```
Error: rpc error: code = InvalidArgument desc = failed to execute message; message index: 0: Unauthorized: execute wasm contract failed: invalid request
```
Which makes sense since `wallet2` is not the owner of `fred` record.