### PR TITLE
`cd nameservice` -> `cd contracts/nameservice`

### DIFF
--- a/docs_versioned_docs/version-0.16/02-getting-started/04-compile-contract.md
+++ b/docs_versioned_docs/version-0.16/02-getting-started/04-compile-contract.md
@@ -22,7 +22,7 @@ git clone https://github.com/InterWasm/cw-contracts
 cd cw-contracts
 git fetch --tags
 git checkout nameservice-0.11.0
-cd nameservice
+cd contracts/nameservice
 
 cargo wasm
 ```


### PR DESCRIPTION
Believe that [this](https://github.com/InterWasm/cw-contracts/commit/ac4c2b93c3f1aa2888f5b66be1edcf43ba27cfd3#diff-b094db7ce2f99cbcbde7ec178a6754bac666e2192f076807acbd70d49ddd0559) commit moved these over.