### PR TITLE
Add missing # on macro

### DIFF
--- a/docs/04-smart-contracts/11-migration.md
+++ b/docs/04-smart-contracts/11-migration.md
@@ -19,7 +19,7 @@ const CONTRACT_NAME: &str = "crates.io:my-crate-name";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 
-[cfg_attr(not(feature = "library"), entry_point)]
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(deps: DepsMut, env: Env, info: MessageInfo, msg: InstantiateMsg) -> Response {
     // Use CW2 to set the contract version, this is needed for migrations
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;


### PR DESCRIPTION
Found a typo on the documentation.

There is a `#` missing on the instantiate macro.