### PR TITLE
Fix typo in 05-interact-with-contract.md

### DIFF
--- a/docs/02-getting-started/05-interact-with-contract.md
+++ b/docs/02-getting-started/05-interact-with-contract.md
@@ -64,7 +64,7 @@ wasmd query bank balances $CONTRACT $NODE
 
 # Upon instantiation the cw_nameservice contract will store the instatiation message data in the contract's storage with the storage key "config".
 # Query the entire contract state
-wasmd query wasm contract-state all $CONTRACT $
+wasmd query wasm contract-state all $CONTRACT $NODE
 ```
 ```json
 models:


### PR DESCRIPTION
There is a missing field(NODE), in the command for querying the contract state. A `$` is present without any variable name. Changed it to `$NODE`.