### PR TITLE
Rename HandleMsg

### DIFF
--- a/cw-plus/cw2/spec.md
+++ b/cw-plus/cw2/spec.md
@@ -8,7 +8,7 @@ Repo
 link: [https://github.com/CosmWasm/cw-plus/tree/master/packages/cw2](https://github.com/CosmWasm/cw-plus/tree/master/packages/cw2)
 
 Most of the CW* specs are focused on the *public interfaces*
-of the contract. The APIs used for `HandleMsg` or `QueryMsg`. However, when we wish to migrate from contract A to
+of the contract. The APIs used for `ExecuteMsg` or `QueryMsg`. However, when we wish to migrate from contract A to
 contract B, contract B needs to be aware somehow of how the *state was encoded*.
 
 Generally we use Singletons and Buckets to store the state, but if I upgrade to a `cw20-with-bonding-curve` contract, it

--- a/cw-tokens/cw20-bonding.md
+++ b/cw-tokens/cw20-bonding.md
@@ -13,8 +13,8 @@ Source code is at [cw20-bonding](https://github.com/CosmWasm/cw-tokens/tree/main
 There are two variants - accepting native tokens and accepting cw20 tokens as the *reserve* token (this is the token
 that is input to the bonding curve).
 
-Minting: When the input is sent to the contract (either via `HandleMsg::Buy{}`
-with native tokens, or via `HandleMsg::Receive{}` with cw20 tokens), those tokens remain on the contract and it issues
+Minting: When the input is sent to the contract (either via `ExecuteMsg::Buy{}`
+with native tokens, or via `ExecuteMsg::Receive{}` with cw20 tokens), those tokens remain on the contract and it issues
 it's own token to the sender's account (known as *supply* token).
 
 Burning: We override the burn function to not only burn the requested tokens, but also release a proper number of the

--- a/cw-tokens/cw20-escrow.md
+++ b/cw-tokens/cw20-escrow.md
@@ -22,7 +22,7 @@ We also add a function called "top_up", which allows anyone to add more funds to
 ## Token types {#token-types}
 
 This contract is meant not just to be functional, but also to work as a simple example of an cw20 "Receiver". And
-demonstrate how the same calls can be fed native tokens (via typical `HandleMsg` route), or cw20 tokens (via `Receiver`
+demonstrate how the same calls can be fed native tokens (via typical `ExecuteMsg` route), or cw20 tokens (via `Receiver`
 interface).
 
 Both `create` and `top_up` can be called directly (with a payload of native tokens), or from a cw20 contract using

--- a/tutorials/simple-option/develop.md
+++ b/tutorials/simple-option/develop.md
@@ -89,14 +89,14 @@ using macros. More read [Rust docs / Derive](https://doc.rust-lang.org/stable/ru
 * _counter_offer_ is [strike price](https://www.investopedia.com/terms/s/strikeprice.asp).
   :::
 
-### HandleMsg {#handlemsg}
+### ExecuteMsg {#ExecuteMsg}
 
-Contract execution is branched using `HandleMsg` enum. Each field defines a message and content of that message.
+Contract execution is branched using `ExecuteMsg` enum. Each field defines a message and content of that message.
 
 ```rust
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum HandleMsg {
+pub enum ExecuteMsg {
   /// Owner can transfer to a new owner
   Transfer { recipient: HumanAddr },
   /// Owner can post counter_offer on unexpired option to execute and get the collateral
@@ -243,12 +243,12 @@ pub fn handle(
   deps: DepsMut,
   env: Env,
   info: MessageInfo,
-  msg: HandleMsg,
+  msg: ExecuteMsg,
 ) -> Result<HandleResponse, ContractError> {
   match msg {
-    HandleMsg::Transfer { recipient } => handle_transfer(deps, env, info, recipient),
-    HandleMsg::Execute {} => handle_execute(deps, env, info),
-    HandleMsg::Burn {} => handle_burn(deps, env, info),
+    ExecuteMsg::Transfer { recipient } => handle_transfer(deps, env, info, recipient),
+    ExecuteMsg::Execute {} => handle_execute(deps, env, info),
+    ExecuteMsg::Burn {} => handle_burn(deps, env, info),
   }
 }
 


### PR DESCRIPTION
Renamed HandleMsg to ExecuteMsg for pages without a specific version. Migrations, change logs, and old versioned pages such as "0.14" remained same.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202508658887047