### PR TITLE
Adding windows alternative `docker run` command for optimizing the wasm binary

### DIFF
--- a/dev-academy/develop-smart-contract/01-intro.md
+++ b/dev-academy/develop-smart-contract/01-intro.md
@@ -346,6 +346,14 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer:0.12.6
 ```
 
+On Windows, you can run the following command instead from the root of your smart contract's project folder.
+```powershell
+docker run --rm -v ${pwd}:/code `
+ --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
+ --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
+ cosmwasm/rust-optimizer:0.12.6
+```
+
 This will result in an optimized .wasm binary under the folder `/artifacts` in your project directory.
 
 :::note optional

--- a/docs/02-getting-started/04-compile-contract.md
+++ b/docs/02-getting-started/04-compile-contract.md
@@ -84,4 +84,12 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer:0.12.6
 ```
 
+On Windows, you can use the following command instead
+```powershell
+docker run --rm -v ${pwd}:/code `
+ --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
+ --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
+ cosmwasm/rust-optimizer:0.12.6
+```
+
 The binary will be under the folder `artifacts` and its size will be `138 kB`.

--- a/docs/04-smart-contracts/08-compilation.md
+++ b/docs/04-smart-contracts/08-compilation.md
@@ -28,3 +28,11 @@ sudo docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   cosmwasm/workspace-optimizer:0.12.4
 ```
+
+On Windows, you can use the following command instead
+```powershell
+docker run --rm -v ${pwd}:/code `
+ --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
+ --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
+ cosmwasm/rust-optimizer:0.12.6
+```

--- a/docs/04-smart-contracts/10-verify.md
+++ b/docs/04-smart-contracts/10-verify.md
@@ -108,6 +108,15 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/workspace-optimizer:0.12.4
 ```
 
+On Windows, you can use the following command instead
+```powershell
+docker run --rm -v ${pwd}:/code `
+ --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
+ --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
+ cosmwasm/rust-optimizer:0.12.6
+```
+
+
 Hashes will be generated at `./artifacts/checksums.txt`.
 
 :::warning

--- a/tutorials/simple-option/develop.md
+++ b/tutorials/simple-option/develop.md
@@ -410,6 +410,14 @@ docker run --rm -v "$(pwd)":/code \
   cosmwasm/rust-optimizer:0.10.7
 ```
 
+On Windows, you can use the following command instead
+```powershell
+docker run --rm -v ${pwd}:/code `
+ --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
+ --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
+ cosmwasm/rust-optimizer:0.10.7
+```
+
 You want to use the command above before deploying to the chain.
 
 ### Schema {#schema}


### PR DESCRIPTION
The default given docker run command for Smart Contract binary optimization does not work on windows.
This PR includes a windows-compatible alternative with same behavior.