### PR TITLE
Fix broken link to Cosmos docs for Events

### DIFF
--- a/docs/04-smart-contracts/06-events.md
+++ b/docs/04-smart-contracts/06-events.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 Most entry point functions return a type of `Result<Response, ContractError>`.
 
-Within this, `Response` is a wrapper around [Events](https://docs.cosmos.network/v0.42/core/events.html) in the Cosmos
+Within this, `Response` is a wrapper around [Events](https://docs.cosmos.network/main/core/events.html) in the Cosmos
 SDK.
 
 The `Response` type should be returned as the successful result of a contract entry point (i.e. `instantiate`


### PR DESCRIPTION
On this page:
https://docs.cosmwasm.com/docs/1.0/smart-contracts/events

Fixed a broken link