### PR TITLE
cw-plus changed master » main branch

### DIFF
--- a/cw-plus/cw1/cw1-subkeys.md
+++ b/cw-plus/cw1/cw1-subkeys.md
@@ -8,7 +8,7 @@ this document is out of date
 
 # CW1 Subkeys
 
-[cw1 Subkeys](https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw1-subkeys)
+[cw1 Subkeys](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw1-subkeys)
 is inspired
 by [Cosmos SDK feature proposal](https://forum.cosmos.network/t/proposal-adding-subkey-feature-to-cosmos-sdk-and-apply-it-to-the-hub/2358)
 .

--- a/cw-plus/cw1/cw1-whitelist.md
+++ b/cw-plus/cw1/cw1-whitelist.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # CW1 Whitelist
 
-[cw1 Whitelist](https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw1-whitelist) may be the simplest
+[cw1 Whitelist](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw1-whitelist) may be the simplest
 implementation of cw1, a whitelist of addresses. It contains a set of admins that are defined upon creation. Any of
 those admins may `Execute` any message via the contract, per the cw1 spec.
 

--- a/cw-plus/cw1/intro.md
+++ b/cw-plus/cw1/intro.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # CW1 Spec: Proxy Contracts
 
-[cw1](https://github.com/CosmWasm/cw-plus/tree/master/packages/cw1) is a specification for proxy contracts based
+[cw1](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw1) is a specification for proxy contracts based
 on CosmWasm. It is a very simple, but flexible interface designed for the case where one contract is meant to hold
 assets (or rights) on behalf of other contracts.
 

--- a/cw-plus/cw2/spec.md
+++ b/cw-plus/cw2/spec.md
@@ -5,7 +5,7 @@ title: CW2 Spec
 # CW2 Spec: Contract Info for Migration
 
 Repo
-link: [https://github.com/CosmWasm/cw-plus/tree/master/packages/cw2](https://github.com/CosmWasm/cw-plus/tree/master/packages/cw2)
+link: [https://github.com/CosmWasm/cw-plus/tree/main/packages/cw2](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw2)
 
 Most of the CW* specs are focused on the *public interfaces*
 of the contract. The APIs used for `ExecuteMsg` or `QueryMsg`. However, when we wish to migrate from contract A to

--- a/cw-plus/cw20/spec.md
+++ b/cw-plus/cw20/spec.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # CW20 Spec: Fungible Tokens
 
 cw20 package source
-code: [https://github.com/CosmWasm/cw-plus/tree/master/packages/cw20](https://github.com/CosmWasm/cw-plus/tree/master/packages/cw20)
+code: [https://github.com/CosmWasm/cw-plus/tree/main/packages/cw20](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw20)
 
 cw20 is a specification for fungible tokens based on CosmWasm. The name and design is loosely based on Ethereum's ERC20
 standard, but many changes have been made. The types in here can be imported by contracts that wish to implement this

--- a/cw-plus/cw3/cw3-fixed-spec.md
+++ b/cw-plus/cw3/cw3-fixed-spec.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # CW3 Fixed Multisig
 
 cw3-fixed-multisig source
-code: [https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw3-fixed-multisig](https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw3-fixed-multisig)
+code: [https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw3-fixed-multisig](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw3-fixed-multisig)
 
 This is a simple implementation of the [cw3 spec](spec.md). It is a multisig with a fixed set of addresses created upon
 initialization. Each address may have the same weight (K of N), or some may have extra voting power. This works much

--- a/cw-plus/cw3/cw3-flex-spec.md
+++ b/cw-plus/cw3/cw3-flex-spec.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 # CW3 Flexible Multisig
 
 cw3-flex-multisig source
-code: [https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw3-flex-multisig](https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw3-flex-multisig)
+code: [https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw3-flex-multisig](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw3-flex-multisig)
 
 This builds on [cw3-fixed-multisig](cw3-fixed-spec.md) with a more powerful implementation of the [cw3 spec](spec.md).
 It is a multisig contract that is backed by a

--- a/cw-plus/cw3/spec.md
+++ b/cw-plus/cw3/spec.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # CW3 Spec: MultiSig/Voting Contracts
 
-[cw3](https://github.com/CosmWasm/cw-plus/tree/master/packages/cw3) is a specification for voting contracts based
+[cw3](https://github.com/CosmWasm/cw-plus/tree/main/packages/cw3) is a specification for voting contracts based
 on CosmWasm. It is an extension of cw1 (which served as an immediate 1 of N multisig). In this case, no key can
 immediately execute, but only propose a set of messages for execution. The proposal, subsequent approvals, and signature
 aggregation all happen on chain.

--- a/cw-plus/cw4/cw4-group-spec.md
+++ b/cw-plus/cw4/cw4-group-spec.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # CW4 Group
 
 cw4-group source
-code: [https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw4-group](https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw4-group)
+code: [https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw4-group](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw4-group)
 
 This is a basic implementation of the [cw4 spec](spec.md). It fulfills all elements of the spec, including the raw query
 lookups, and it designed to be used as a backing storage for

--- a/cw-plus/cw4/cw4-stake-spec.md
+++ b/cw-plus/cw4/cw4-stake-spec.md
@@ -5,7 +5,7 @@ sidebar_position: 3
 # CW4 Stake
 
 cw4-stake source
-code: [https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw4-stake](https://github.com/CosmWasm/cw-plus/tree/master/contracts/cw4-stake)
+code: [https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw4-stake](https://github.com/CosmWasm/cw-plus/tree/main/contracts/cw4-stake)
 
 This is a second implementation of the [cw4 spec](spec.md). It fulfills all elements of the spec, including the raw
 query lookups, and is designed to be used as a backing storage for


### PR DESCRIPTION
As I was going through the docs I kept seeing GitHub throw this medium-sized banner at me, alerting me that the `master` branch had been changed to `main`. Finally realized it does that when you specify the old branch.

It kind of takes up some real estate:

<img width="1029" alt="Screen Shot 2022-07-13 at 8 04 56 PM" src="https://user-images.githubusercontent.com/1042667/178890762-eb54caf9-d167-4042-b1c1-604e7652ea3c.png">

so as a small enhancement, thought I'd throw a PR up since I'm in the zone.
