### PR TITLE
Updated Every Instance of cosmwasm/rust-optimizer to 0.12.11 on Docs

### DIFF
--- a/docs/02-getting-started/04-compile-contract.md
+++ b/docs/02-getting-started/04-compile-contract.md
@@ -81,7 +81,7 @@ Navigate to the project root and run the following command:
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.6
+  cosmwasm/rust-optimizer:0.12.11
 ```
 
 On Windows, you can use the following command instead
@@ -89,7 +89,7 @@ On Windows, you can use the following command instead
 docker run --rm -v ${pwd}:/code `
  --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
- cosmwasm/rust-optimizer:0.12.6
+ cosmwasm/rust-optimizer:0.12.11
 ```
 
 The binary will be under the folder `artifacts` and its size will be `138 kB`.

--- a/docs/04-smart-contracts/08-compilation.md
+++ b/docs/04-smart-contracts/08-compilation.md
@@ -34,5 +34,5 @@ On Windows, you can use the following command instead
 docker run --rm -v ${pwd}:/code `
  --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
- cosmwasm/rust-optimizer:0.12.6
+ cosmwasm/rust-optimizer:0.12.11
 ```

--- a/docs/04-smart-contracts/10-verify.md
+++ b/docs/04-smart-contracts/10-verify.md
@@ -116,7 +116,7 @@ On Windows, you can use the following command instead
 docker run --rm -v ${pwd}:/code `
  --mount type=volume,source="$("$(Split-Path -Path $pwd -Leaf)")_cache",target=/code/target `
  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry `
- cosmwasm/rust-optimizer:0.12.6
+ cosmwasm/rust-optimizer:0.12.11
 ```
 
 


### PR DESCRIPTION
Because Using the Rust-Optimizer 0.12.6 was failing 😢

Using the latest version solves this problem below 🤧

```
error: can't compile schema generator for the wasm32 arch
       hint: are you trying to compile a smart contract without specifying --lib?
  --> src/bin/schema.rs:6:5
   |
6  | /     writeapi! {
7  | |         instantiate: InstantiateMsg,
8  | |         execute: ExecuteMsg,
9  | |         query: QueryMsg,
10 | |     }
   | |__^
   |
   = note: this error originates in the macro write_api (in Nightly builds, run with -Z macro-backtrace for more info)
   ```